### PR TITLE
fix: uuid_to_decimal logic with undefined behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ Here is the results on PostgreSQL 15 (Ubuntu 24.04 LTS) for 100 000 iterations:
 ```
 postgres=# create extension uuid_decimal;
 CREATE EXTENSION
-
 postgres=# CREATE TEMPORARY TABLE uuids AS
 SELECT gen_random_uuid() AS id FROM generate_series(1, 100000);
 SELECT 100000
 postgres=# EXPLAIN ANALYZE VERBOSE
-SELECT decimal_to_uuid(uuid_to_decimal(id)) FROM uuids;
+SELECT decimal_to_uuid(uuid_to_decimal(id))
+FROM uuids;
                                                       QUERY PLAN
 ----------------------------------------------------------------------------------------------------------------------
- Seq Scan on pg_temp.uuids  (cost=0.00..2042.27 rows=100085 width=16) (actual time=0.015..51.352 rows=100000 loops=1)
+ Seq Scan on pg_temp.uuids  (cost=0.00..2042.27 rows=100085 width=16) (actual time=0.014..40.866 rows=100000 loops=1)
    Output: decimal_to_uuid(uuid_to_decimal(id))
- Planning Time: 12.202 ms
- Execution Time: 53.231 ms
+ Planning Time: 0.062 ms
+ Execution Time: 42.647 ms
 (4 rows)
 ```

--- a/uint_utils.c
+++ b/uint_utils.c
@@ -74,8 +74,14 @@ char* uint128_to_string(uint128 value, char* buffer, size_t buffer_size) {
         // Get the last digit
         uint64_t digit = value % 10;
         value /= 10;
+        ptr--;
+
+        if (ptr < buffer) {
+            elog(ERROR, "Pointer overflow");
+        }
+
         // Prepend the digit to the string
-        *(--ptr) = '0' + digit;
+        *ptr = '0' + digit;
     }
 
     return ptr; // Return the pointer to the start of the string

--- a/uuid_decimal.c
+++ b/uuid_decimal.c
@@ -49,7 +49,6 @@ Datum uuid_to_decimal(PG_FUNCTION_ARGS)
     char *num_str;
     uint128 uuid_num;
     pg_uuid_t* uuid;
-    Numeric temp;
     Numeric result;
 
     uuid = PG_GETARG_UUID_P(0);
@@ -58,18 +57,14 @@ Datum uuid_to_decimal(PG_FUNCTION_ARGS)
     str_buf = palloc(41);
     num_str = uint128_to_string(uuid_num, str_buf, 41);
 
-    temp = DatumGetNumeric(DirectFunctionCall1(
+    result = DatumGetNumeric(DirectFunctionCall3(
         numeric_in,
-        CStringGetDatum(num_str)
-    ));
-
-    result = DatumGetNumeric(DirectFunctionCall1(
-        numeric_trim_scale,
-        NumericGetDatum(temp)
+        CStringGetDatum(num_str),
+        ObjectIdGetDatum(0),
+        Int32GetDatum(-1)
     ));
 
     pfree(str_buf);
-    pfree(temp);
 
     PG_RETURN_NUMERIC(result);
 }


### PR DESCRIPTION
Here is example how `numeric_in` should be properly called - https://github.com/postgres/postgres/blob/c1ff2d8bc5be55e302731a16aaff563b7f03ed7c/src/backend/utils/adt/pg_lsn.c#L238